### PR TITLE
Fixed CsvReaderService bug to not read the inital header of the file

### DIFF
--- a/CreditReferencingConsoleApplication.Tests/ServiceTests/AffordibilityServiceTests.cs
+++ b/CreditReferencingConsoleApplication.Tests/ServiceTests/AffordibilityServiceTests.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
 using Moq;
-using System;
 using System.Collections.Generic;
 using CreditReferencingConsoleApplication.Models;
 using CreditReferencingConsoleApplication.Services;
@@ -11,6 +10,7 @@ namespace CreditReferencingConsoleApplication.Tests.ServiceTests
     [TestFixture]
     public class AffordabilityServiceTests
     {
+        // Example of mocking in case there are multiple dependencies needed
         private Mock<IAffordabilityService> _mockAffordabilityService;
 
         [SetUp]

--- a/CreditReferencingConsoleApplication.Tests/ServiceTests/CsvReaderServiceTests.cs
+++ b/CreditReferencingConsoleApplication.Tests/ServiceTests/CsvReaderServiceTests.cs
@@ -37,7 +37,7 @@ namespace CreditReferencingConsoleApplication.Tests
 
             // Assert
             Assert.NotNull(transactions);
-            Assert.AreEqual(5, transactions.Count); // Adjust based on your mock data
+            Assert.AreEqual(5, transactions.Count);
 
             // Clean up
             File.Delete(filePath);
@@ -61,7 +61,7 @@ namespace CreditReferencingConsoleApplication.Tests
 
             // Assert
             Assert.NotNull(properties);
-            Assert.AreEqual(4, properties.Count); // Adjust based on your mock data
+            Assert.AreEqual(4, properties.Count);
 
             // Clean up
             File.Delete(filePath);
@@ -71,6 +71,7 @@ namespace CreditReferencingConsoleApplication.Tests
         {
             string tempFilePath = Path.GetTempFileName();
             File.WriteAllText(tempFilePath, csvContent);
+            
             return tempFilePath;
         }
     }

--- a/CreditReferencingConsoleApplication/Services/CsvReaderService.cs
+++ b/CreditReferencingConsoleApplication/Services/CsvReaderService.cs
@@ -88,20 +88,21 @@ namespace CreditReferencingConsoleApplication.Services
                 string[] lines = File.ReadAllLines(filePath);
 
                 // Ensure there's at least one line with data
-                if(lines.Length == 0)
+                if(lines.Length <= 1)
                 {
-                    throw new InvalidDataException("CSV file is empty.");
+                    throw new InvalidDataException("CSV file does not contain enough data.");
                 }
 
-                // Process each line in the CSV file
+                // Skip the header line and process each subsequent line in the CSV file
                 properties = lines
+                    .Skip(1) // Skip the header line
                     .Where(line => !string.IsNullOrWhiteSpace(line))
-                    .Select(line => SplitCsvLine(line))              
-                    .Where(fields => fields.Length >= 3)             
+                    .Select(line => SplitCsvLine(line))
+                    .Where(fields => fields.Length >= 3)
                     .Select(fields => new Property
                     {
                         Id = int.TryParse(fields[0].Trim('"'), out int id) ? id : 0,
-                        Address = fields[1].Trim('"'),                               
+                        Address = fields[1].Trim('"'),
                         RentPerMonth = decimal.TryParse(fields[2].Trim('"'), NumberStyles.Currency, CultureInfo.InvariantCulture, out decimal rent) ? rent : 0m // Parse RentPerMonth
                     })
                     .ToList();


### PR DESCRIPTION
### Description

**Fixed CsvReaderService Bug to Not Read the Initial Header of the File**

#### Problem
The `CsvReaderService` was incorrectly reading the first line of the csv, which led to the header being processed and included in the list of properties. This caused unexpected behavior, including incorrect counts and data being processed

#### Solution
- **CSV Reader Service Update**: Modified the `ReadProperties` methods to correctly skip the header row and only process the actual data rows. This ensures that the headers are not mistakenly included in the list of transactions and properties

#### Impact
- The update ensures that the header row is not treated as data, leading to accurate reading and processing of CSV files
- This fix resolves issues with incorrect counts and invalid data entries that were previously caused by including the header row